### PR TITLE
Add std_srvs support

### DIFF
--- a/include/ros2in1_support/conversions/std_srvs.h
+++ b/include/ros2in1_support/conversions/std_srvs.h
@@ -32,6 +32,13 @@ inline void convert_2_to_1<std_srvs::Empty::Request, std_srvs::srv::Empty::Reque
 
 template <>
 inline void convert_1_to_2<std_srvs::srv::Empty::Response, std_srvs::Empty::Response>(
+    const std_srvs::Empty::Response&,
+    std_srvs::srv::Empty::Response&) {
+  // empty
+}
+
+template <>
+inline void convert_1_to_2<std_srvs::srv::Empty::Response, std_srvs::Empty::Response>(
     std_srvs::Empty::Response&&,
     std_srvs::srv::Empty::Response&) {
   // empty


### PR DESCRIPTION

# Goal

To make available some `std_srvs` services to ROS 2-in-1 support.

## Description

This PR adds the following services to `ros2in1_support`:

* [x] `std_srvs::Emtpy`
* [ ] `std_srvs::Trigger`
