### PR TITLE
Add subscriptions to ROS 2-in1 Support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/include/ros2in1_support/conversions/builtin_interfaces.h
+++ b/include/ros2in1_support/conversions/builtin_interfaces.h
@@ -29,8 +29,24 @@ inline void convert_2_to_1<ros::Time, builtin_interfaces::msg::Time>(
 }
 
 template <>
+inline void convert_2_to_1<ros::Time, builtin_interfaces::msg::Time>(
+    builtin_interfaces::msg::Time&& ros2_msg,
+    ros::Time& ros1_msg) {
+  ros1_msg.sec = static_cast<uint32_t>(ros2_msg.sec);
+  ros1_msg.nsec = ros2_msg.nanosec;
+}
+
+template <>
 inline void convert_1_to_2<builtin_interfaces::msg::Time, ros::Time>(
     const ros::Time& ros1_msg,
+    builtin_interfaces::msg::Time& ros2_msg) {
+  ros2_msg.sec = static_cast<int32_t>(ros1_msg.sec);
+  ros2_msg.nanosec = ros1_msg.nsec;
+}
+
+template <>
+inline void convert_1_to_2<builtin_interfaces::msg::Time, ros::Time>(
+    ros::Time&& ros1_msg,
     builtin_interfaces::msg::Time& ros2_msg) {
   ros2_msg.sec = static_cast<int32_t>(ros1_msg.sec);
   ros2_msg.nanosec = ros1_msg.nsec;

--- a/include/ros2in1_support/conversions/common.h
+++ b/include/ros2in1_support/conversions/common.h
@@ -17,32 +17,32 @@ namespace ros2in1_support {
 namespace conversions {
 
 template <typename Ros2MessageT, typename Ros1MessageT>
-inline void convert_1_to_2(const Ros1MessageT& ros1_msg, Ros2MessageT& ros2_msg);
+__attribute__((unused)) inline void convert_1_to_2(const Ros1MessageT& ros1_msg, Ros2MessageT& ros2_msg);
 
 template <typename Ros2MessageT, typename Ros1MessageT>
 inline void convert_1_to_2(Ros1MessageT&& ros1_msg, Ros2MessageT& ros2_msg) {
-  convert_1_to_2(static_cast<const Ros1MessageT&>(ros1_msg), ros2_msg);
+  convert_1_to_2<Ros2MessageT, Ros1MessageT>(static_cast<const Ros1MessageT&>(ros1_msg), ros2_msg);
 }
 
 template <typename Ros1MessageT, typename Ros2MessageT>
-inline void convert_2_to_1(const Ros2MessageT& ros2_msg, Ros1MessageT& ros1_msg);
+__attribute__((unused)) inline void convert_2_to_1(const Ros2MessageT& ros2_msg, Ros1MessageT& ros1_msg);
 
 template <typename Ros1MessageT, typename Ros2MessageT>
 inline void convert_2_to_1(Ros2MessageT&& ros2_msg, Ros1MessageT& ros1_msg) {
-  convert_2_to_1(static_cast<const Ros2MessageT&>(ros2_msg), ros1_msg);
+  convert_2_to_1<Ros1MessageT, Ros2MessageT>(static_cast<const Ros2MessageT&>(ros2_msg), ros1_msg);
 }
 
 template <typename Ros2MessageT, typename Ros1MessageT>
 inline Ros2MessageT convert_1_to_2(const Ros1MessageT& ros1_msg) {
   Ros2MessageT ros2_msg;
-  ::ros2in1_support::conversions::convert_1_to_2(ros1_msg, ros2_msg);
+  ::ros2in1_support::conversions::convert_1_to_2<Ros2MessageT, Ros1MessageT>(ros1_msg, ros2_msg);
   return ros2_msg;
 }
 
 template <typename Ros1MessageT, typename Ros2MessageT>
 inline Ros1MessageT convert_2_to_1(const Ros2MessageT& ros2_msg) {
   Ros1MessageT ros1_msg;
-  ::ros2in1_support::conversions::convert_2_to_1(ros2_msg, ros1_msg);
+  ::ros2in1_support::conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(ros2_msg, ros1_msg);
   return ros1_msg;
 }
 
@@ -54,7 +54,7 @@ inline void convert_1_to_2(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros1_it != ros1_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_1_to_2(*ros1_it, *ros2_it);
+    ::ros2in1_support::conversions::convert_1_to_2<Ros2MessageT, Ros1MessageT>(*ros1_it, *ros2_it);
   }
 }
 
@@ -66,7 +66,7 @@ inline void convert_1_to_2(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros1_it != ros1_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_1_to_2(std::move(*ros1_it), *ros2_it);
+    ::ros2in1_support::conversions::convert_1_to_2<Ros2MessageT, Ros1MessageT>(std::move(*ros1_it), *ros2_it);
   }
 }
 
@@ -92,7 +92,7 @@ inline void convert_2_to_1(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros2_it != ros2_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_2_to_1(*ros2_it, *ros1_it);
+    ::ros2in1_support::conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(*ros2_it, *ros1_it);
   }
 }
 
@@ -104,7 +104,7 @@ inline void convert_2_to_1(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros2_it != ros2_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_2_to_1(std::move(*ros2_it), *ros1_it);
+    ::ros2in1_support::conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(std::move(*ros2_it), *ros1_it);
   }
 }
 
@@ -129,7 +129,7 @@ inline void convert_1_to_2(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros1_it != ros1_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_1_to_2(*ros1_it, *ros2_it);
+    ::ros2in1_support::conversions::convert_1_to_2<Ros2MessageT, Ros1MessageT>(*ros1_it, *ros2_it);
   }
 }
 
@@ -140,7 +140,7 @@ inline void convert_1_to_2(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros1_it != ros1_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_1_to_2(std::move(*ros1_it), *ros2_it);
+    ::ros2in1_support::conversions::convert_1_to_2<Ros2MessageT, Ros1MessageT>(std::move(*ros1_it), *ros2_it);
   }
 }
 
@@ -165,7 +165,7 @@ inline void convert_2_to_1(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros2_it != ros2_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_2_to_1(*ros2_it, *ros1_it);
+    ::ros2in1_support::conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(*ros2_it, *ros1_it);
   }
 }
 
@@ -176,7 +176,7 @@ inline void convert_2_to_1(
   auto ros1_it = ros1_msg.begin();
   auto ros2_it = ros2_msg.begin();
   for( ; ros2_it != ros2_msg.end(); ++ros1_it, ++ros2_it) {
-    ::ros2in1_support::conversions::convert_2_to_1(std::move(*ros2_it), *ros1_it);
+    ::ros2in1_support::conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(std::move(*ros2_it), *ros1_it);
   }
 }
 

--- a/include/ros2in1_support/conversions/geometry_msgs.h
+++ b/include/ros2in1_support/conversions/geometry_msgs.h
@@ -237,30 +237,6 @@ inline void convert_1_to_2<geometry_msgs::msg::TransformStamped, geometry_msgs::
   convert_1_to_2(ros1_msg.transform, ros2_msg.transform);
 }
 
-template <>
-inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
-    const geometry_msgs::msg::Twist& ros2_msg,
-    geometry_msgs::Twist& ros1_msg) {
-  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.linear, ros1_msg.linear);
-  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.angular, ros1_msg.angular);
-}
-
-template <>
-inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
-    geometry_msgs::msg::Twist&& ros2_msg,
-    geometry_msgs::Twist& ros1_msg) {
-  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.linear, ros1_msg.linear);
-  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.angular, ros1_msg.angular);
-}
-
-template <>
-inline void convert_1_to_2<geometry_msgs::msg::Twist, geometry_msgs::Twist>(
-    const geometry_msgs::Twist& ros1_msg,
-    geometry_msgs::msg::Twist& ros2_msg) {
-  convert_1_to_2(ros1_msg.linear, ros2_msg.linear);
-  convert_1_to_2(ros1_msg.angular, ros2_msg.angular);
-}
-
 }  // namespace conversions
 }  // namespace ros2in1_support
 

--- a/include/ros2in1_support/conversions/geometry_msgs.h
+++ b/include/ros2in1_support/conversions/geometry_msgs.h
@@ -89,8 +89,8 @@ template <>
 inline void convert_2_to_1<geometry_msgs::PointStamped, geometry_msgs::msg::PointStamped>(
     const geometry_msgs::msg::PointStamped& ros2_msg,
     geometry_msgs::PointStamped& ros1_msg) {
-  convert_2_to_1(ros2_msg.header, ros1_msg.header);
-  convert_2_to_1(ros2_msg.point, ros1_msg.point);
+  convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(ros2_msg.header, ros1_msg.header);
+  convert_2_to_1<geometry_msgs::Point, geometry_msgs::msg::Point>(ros2_msg.point, ros1_msg.point);
 }
 
 template <>
@@ -125,8 +125,8 @@ template <>
 inline void convert_2_to_1<geometry_msgs::Pose, geometry_msgs::msg::Pose>(
     const geometry_msgs::msg::Pose& ros2_msg,
     geometry_msgs::Pose& ros1_msg) {
-  convert_2_to_1(ros2_msg.position, ros1_msg.position);
-  convert_2_to_1(ros2_msg.orientation, ros1_msg.orientation);
+  convert_2_to_1<geometry_msgs::Point, geometry_msgs::msg::Point>(ros2_msg.position, ros1_msg.position);
+  convert_2_to_1<geometry_msgs::Quaternion, geometry_msgs::msg::Quaternion>(ros2_msg.orientation, ros1_msg.orientation);
 }
 
 template <>
@@ -141,7 +141,7 @@ template <>
 inline void convert_2_to_1<geometry_msgs::PoseArray, geometry_msgs::msg::PoseArray>(
     const geometry_msgs::msg::PoseArray& ros2_msg,
     geometry_msgs::PoseArray& ros1_msg) {
-  convert_2_to_1(ros2_msg.header, ros1_msg.header);
+  convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(ros2_msg.header, ros1_msg.header);
   convert_2_to_1(ros2_msg.poses, ros1_msg.poses);
 }
 
@@ -157,8 +157,8 @@ template <>
 inline void convert_2_to_1<geometry_msgs::PoseStamped, geometry_msgs::msg::PoseStamped>(
     const geometry_msgs::msg::PoseStamped& ros2_msg,
     geometry_msgs::PoseStamped& ros1_msg) {
-  convert_2_to_1(ros2_msg.header, ros1_msg.header);
-  convert_2_to_1(ros2_msg.pose, ros1_msg.pose);
+  convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(ros2_msg.header, ros1_msg.header);
+  convert_2_to_1<geometry_msgs::Pose, geometry_msgs::msg::Pose>(ros2_msg.pose, ros1_msg.pose);
 }
 
 template <>
@@ -191,8 +191,8 @@ template <>
 inline void convert_2_to_1<geometry_msgs::Vector3Stamped, geometry_msgs::msg::Vector3Stamped>(
     const geometry_msgs::msg::Vector3Stamped& ros2_msg,
     geometry_msgs::Vector3Stamped& ros1_msg) {
-  convert_2_to_1(ros2_msg.header, ros1_msg.header);
-  convert_2_to_1(ros2_msg.vector, ros1_msg.vector);
+  convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(ros2_msg.header, ros1_msg.header);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.vector, ros1_msg.vector);
 }
 
 template <>
@@ -207,8 +207,8 @@ template <>
 inline void convert_2_to_1<geometry_msgs::Transform, geometry_msgs::msg::Transform>(
     const geometry_msgs::msg::Transform& ros2_msg,
     geometry_msgs::Transform& ros1_msg) {
-  convert_2_to_1(ros2_msg.translation, ros1_msg.translation);
-  convert_2_to_1(ros2_msg.rotation, ros1_msg.rotation);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.translation, ros1_msg.translation);
+  convert_2_to_1<geometry_msgs::Quaternion, geometry_msgs::msg::Quaternion>(ros2_msg.rotation, ros1_msg.rotation);
 }
 
 template <>
@@ -223,9 +223,9 @@ template <>
 inline void convert_2_to_1<geometry_msgs::TransformStamped, geometry_msgs::msg::TransformStamped>(
     const geometry_msgs::msg::TransformStamped& ros2_msg,
     geometry_msgs::TransformStamped& ros1_msg) {
-  convert_2_to_1(ros2_msg.header, ros1_msg.header);
+  convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(ros2_msg.header, ros1_msg.header);
   ros1_msg.child_frame_id = ros2_msg.child_frame_id;
-  convert_2_to_1(ros2_msg.transform, ros1_msg.transform);
+  convert_2_to_1<geometry_msgs::Transform, geometry_msgs::msg::Transform>(ros2_msg.transform, ros1_msg.transform);
 }
 
 template <>
@@ -235,6 +235,30 @@ inline void convert_1_to_2<geometry_msgs::msg::TransformStamped, geometry_msgs::
   convert_1_to_2(ros1_msg.header, ros2_msg.header);
   ros2_msg.child_frame_id = ros1_msg.child_frame_id;
   convert_1_to_2(ros1_msg.transform, ros2_msg.transform);
+}
+
+template <>
+inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
+    const geometry_msgs::msg::Twist& ros2_msg,
+    geometry_msgs::Twist& ros1_msg) {
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.linear, ros1_msg.linear);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.angular, ros1_msg.angular);
+}
+
+template <>
+inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
+    geometry_msgs::msg::Twist&& ros2_msg,
+    geometry_msgs::Twist& ros1_msg) {
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.linear, ros1_msg.linear);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.angular, ros1_msg.angular);
+}
+
+template <>
+inline void convert_1_to_2<geometry_msgs::msg::Twist, geometry_msgs::Twist>(
+    const geometry_msgs::Twist& ros1_msg,
+    geometry_msgs::msg::Twist& ros2_msg) {
+  convert_1_to_2(ros1_msg.linear, ros2_msg.linear);
+  convert_1_to_2(ros1_msg.angular, ros2_msg.angular);
 }
 
 }  // namespace conversions

--- a/include/ros2in1_support/conversions/nav_msgs.h
+++ b/include/ros2in1_support/conversions/nav_msgs.h
@@ -115,8 +115,7 @@ inline void convert_2_to_1<nav_msgs::Odometry, nav_msgs::msg::Odometry>(
   convert_2_to_1(ros2_msg.pose.pose.position, ros1_msg.pose.pose.position);
   convert_2_to_1(ros2_msg.pose.pose.orientation, ros1_msg.pose.pose.orientation);
   convert_2_to_1(ros2_msg.pose.covariance, ros1_msg.pose.covariance);
-  convert_2_to_1(ros2_msg.twist.twist.linear, ros1_msg.twist.twist.linear);
-  convert_2_to_1(ros2_msg.twist.twist.angular, ros1_msg.twist.twist.angular);
+  convert_2_to_1(ros2_msg.twist.twist, ros1_msg.twist.twist);
   convert_2_to_1(ros2_msg.twist.covariance, ros1_msg.twist.covariance);
 }
 
@@ -129,8 +128,7 @@ inline void convert_1_to_2<nav_msgs::msg::Odometry, nav_msgs::Odometry>(
   convert_1_to_2(ros1_msg.pose.pose.position, ros2_msg.pose.pose.position);
   convert_1_to_2(ros1_msg.pose.pose.orientation, ros2_msg.pose.pose.orientation);
   convert_1_to_2(ros1_msg.pose.covariance, ros2_msg.pose.covariance);
-  convert_1_to_2(ros1_msg.twist.twist.linear, ros2_msg.twist.twist.linear);
-  convert_1_to_2(ros1_msg.twist.twist.angular, ros2_msg.twist.twist.angular);
+  convert_1_to_2(ros1_msg.twist.twist, ros2_msg.twist.twist);
   convert_1_to_2(ros1_msg.twist.covariance, ros2_msg.twist.covariance);
 }
 

--- a/include/ros2in1_support/conversions/nav_msgs.h
+++ b/include/ros2in1_support/conversions/nav_msgs.h
@@ -159,6 +159,13 @@ inline void convert_2_to_1<nav_msgs::GetMap::Request, nav_msgs::srv::GetMap::Req
 
 template <>
 inline void convert_1_to_2<nav_msgs::srv::GetMap::Response, nav_msgs::GetMap::Response>(
+    const nav_msgs::GetMap::Response& ros1_msg,
+    nav_msgs::srv::GetMap::Response& ros2_msg) {
+  convert_1_to_2(ros1_msg.map, ros2_msg.map);
+}
+
+template <>
+inline void convert_1_to_2<nav_msgs::srv::GetMap::Response, nav_msgs::GetMap::Response>(
     nav_msgs::GetMap::Response&& ros1_msg,
     nav_msgs::srv::GetMap::Response& ros2_msg) {
   convert_1_to_2(std::move(ros1_msg.map), ros2_msg.map);

--- a/include/ros2in1_support/conversions/nav_msgs.h
+++ b/include/ros2in1_support/conversions/nav_msgs.h
@@ -115,7 +115,8 @@ inline void convert_2_to_1<nav_msgs::Odometry, nav_msgs::msg::Odometry>(
   convert_2_to_1(ros2_msg.pose.pose.position, ros1_msg.pose.pose.position);
   convert_2_to_1(ros2_msg.pose.pose.orientation, ros1_msg.pose.pose.orientation);
   convert_2_to_1(ros2_msg.pose.covariance, ros1_msg.pose.covariance);
-  convert_2_to_1(ros2_msg.twist.twist, ros1_msg.twist.twist);
+  convert_2_to_1(ros2_msg.twist.twist.linear, ros1_msg.twist.twist.linear);
+  convert_2_to_1(ros2_msg.twist.twist.angular, ros1_msg.twist.twist.angular);
   convert_2_to_1(ros2_msg.twist.covariance, ros1_msg.twist.covariance);
 }
 
@@ -128,7 +129,8 @@ inline void convert_1_to_2<nav_msgs::msg::Odometry, nav_msgs::Odometry>(
   convert_1_to_2(ros1_msg.pose.pose.position, ros2_msg.pose.pose.position);
   convert_1_to_2(ros1_msg.pose.pose.orientation, ros2_msg.pose.pose.orientation);
   convert_1_to_2(ros1_msg.pose.covariance, ros2_msg.pose.covariance);
-  convert_1_to_2(ros1_msg.twist.twist, ros2_msg.twist.twist);
+  convert_1_to_2(ros1_msg.twist.twist.linear, ros2_msg.twist.twist.linear);
+  convert_1_to_2(ros1_msg.twist.twist.angular, ros2_msg.twist.twist.angular);
   convert_1_to_2(ros1_msg.twist.covariance, ros2_msg.twist.covariance);
 }
 

--- a/include/ros2in1_support/conversions/std_msgs.h
+++ b/include/ros2in1_support/conversions/std_msgs.h
@@ -26,7 +26,7 @@ template <>
 inline void convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(
     const std_msgs::msg::Header& ros2_msg,
     std_msgs::Header& ros1_msg) {
-  convert_2_to_1(ros2_msg.stamp, ros1_msg.stamp);
+  convert_2_to_1<ros::Time, builtin_interfaces::msg::Time>(ros2_msg.stamp, ros1_msg.stamp);
   ros1_msg.frame_id = ros2_msg.frame_id;
 }
 
@@ -34,7 +34,7 @@ template <>
 inline void convert_2_to_1<std_msgs::Header, std_msgs::msg::Header>(
     std_msgs::msg::Header&& ros2_msg,
     std_msgs::Header& ros1_msg) {
-  convert_2_to_1(ros2_msg.stamp, ros1_msg.stamp);
+  convert_2_to_1<ros::Time, builtin_interfaces::msg::Time>(ros2_msg.stamp, ros1_msg.stamp);
   ros1_msg.frame_id = std::move(ros2_msg.frame_id);
 }
 
@@ -42,7 +42,7 @@ template <>
 inline void convert_1_to_2<std_msgs::msg::Header, std_msgs::Header>(
     const std_msgs::Header& ros1_msg,
     std_msgs::msg::Header& ros2_msg) {
-  convert_1_to_2(ros1_msg.stamp, ros2_msg.stamp);
+  convert_1_to_2<builtin_interfaces::msg::Time, ros::Time>(ros1_msg.stamp, ros2_msg.stamp);
   ros2_msg.frame_id = ros1_msg.frame_id;
 }
 
@@ -50,7 +50,7 @@ template <>
 inline void convert_1_to_2<std_msgs::msg::Header, std_msgs::Header>(
     std_msgs::Header&& ros1_msg,
     std_msgs::msg::Header& ros2_msg) {
-  convert_1_to_2(ros1_msg.stamp, ros2_msg.stamp);
+  convert_1_to_2<builtin_interfaces::msg::Time, ros::Time>(ros1_msg.stamp, ros2_msg.stamp);
   ros2_msg.frame_id = std::move(ros1_msg.frame_id);
 }
 

--- a/include/ros2in1_support/subscriber.h
+++ b/include/ros2in1_support/subscriber.h
@@ -68,7 +68,7 @@ void subscribe(ros::NodeHandle& ros1_node, const std::string& topic, uint32_t qu
     [fp, obj](const typename Ros2MessageT::SharedPtr ros2_msg) {
       // Convert ROS 2 message to ROS 1 message
       Ros1MessageT ros1_msg;
-      conversions::convert_2_to_1(*ros2_msg, ros1_msg);
+      conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(*ros2_msg, ros1_msg);
       // Call the ROS 1-style callback
       (obj->*fp)(ros1_msg);
     });
@@ -89,7 +89,7 @@ void subscribe(ros::NodeHandle& ros1_node, const std::string& topic, uint32_t qu
     topic, make_qos_from_transport_hints(queue_size, transport_hints),
     [fp, obj](const typename Ros2MessageT::SharedPtr ros2_msg) {
       Ros1MessageT ros1_msg;
-      conversions::convert_2_to_1(*ros2_msg, ros1_msg);
+      conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(*ros2_msg, ros1_msg);
       // Call the ROS 1-style const callback
       (obj->*fp)(ros1_msg);
     });
@@ -110,7 +110,7 @@ void subscribe(ros::NodeHandle& ros1_node, const std::string& topic, uint32_t qu
     topic, make_qos_from_transport_hints(queue_size, transport_hints),
     [fp, obj](const typename Ros2MessageT::SharedPtr ros2_msg) {
       boost::shared_ptr<Ros1MessageT> ros1_msg = boost::make_shared<Ros1MessageT>();
-      conversions::convert_2_to_1(*ros2_msg, *ros1_msg);
+      conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(*ros2_msg, *ros1_msg);
       // Call the ROS 1-style const callback
       (obj->*fp)(ros1_msg);
     });
@@ -130,7 +130,7 @@ void subscribe(ros::NodeHandle& ros1_node, const std::string& topic, uint32_t qu
     topic, make_qos_from_transport_hints(queue_size, transport_hints),
     [fp, obj](const typename Ros2MessageT::SharedPtr ros2_msg) {
       boost::shared_ptr<Ros1MessageT> ros1_msg = boost::make_shared<Ros1MessageT>();
-      conversions::convert_2_to_1(*ros2_msg, *ros1_msg);
+      conversions::convert_2_to_1<Ros1MessageT, Ros2MessageT>(std::move(*ros2_msg), *ros1_msg);
       // Call the ROS 1-style const callback
       (obj->*fp)(ros1_msg);
     });

--- a/include/ros2in1_support/subscriber.h
+++ b/include/ros2in1_support/subscriber.h
@@ -1,0 +1,189 @@
+/******************************************************************************
+ *  Copyright (c) 2025, Intermodalics BVBA                                    *
+ *  All rights reserved.                                                      *
+ ******************************************************************************/
+
+#ifndef ROS2IN1_SUPPORT_SUBSCRIBER_H
+#define ROS2IN1_SUPPORT_SUBSCRIBER_H
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include <ros/node_handle.h>
+#include <ros/subscriber.h>
+
+#ifdef ROS2_SUPPORT
+#include <rclcpp/node.hpp>
+#include <rclcpp/subscription.hpp>
+
+#include "node.h"
+
+namespace ros2in1_support {
+
+namespace conversions {
+template <typename Ros1MessageT> struct Ros2MessageType;
+}  // namespace conversions
+
+template <typename Ros1MessageT,
+          typename Ros2MessageT = typename conversions::Ros2MessageType<Ros1MessageT>::type>
+class Subscriber {
+ public:
+
+private:
+rclcpp::QoS make_qos_from_transport_hints(uint32_t queue_size, const ros::TransportHints& transport_hints) const {
+  auto reliability = rclcpp::ReliabilityPolicy::SystemDefault;
+  if (transport_hints.isReliable()) {
+    reliability = rclcpp::ReliabilityPolicy::Reliable;
+  } else if (transport_hints.isUnreliable()) {
+    reliability = rclcpp::ReliabilityPolicy::BestEffort;
+  }
+  return rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(queue_size)).reliability(reliability);
+}
+
+public:
+/** First implementation: set up for ROS 2 and ROS 1 */
+template<class M, class T>
+void subscribe(ros::NodeHandle& ros1_node, const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj, 
+  const ros::TransportHints& transport_hints = ros::TransportHints())
+{
+  // Set up ROS 2 subscription with a lambda that converts and calls the ROS 1-style callback
+  rclcpp::Node::SharedPtr node = ros2in1_support::getRos2Node();
+  ros2_subscription_ = node->create_subscription<Ros2MessageT>(
+    topic, make_qos_from_transport_hints(queue_size, transport_hints),
+    [fp, obj](const typename Ros2MessageT::SharedPtr ros2_msg) {
+      // Convert ROS 2 message to ROS 1 message
+      Ros1MessageT ros1_msg;
+      conversions::convert_2_to_1(*ros2_msg, ros1_msg);
+      // Call the ROS 1-style callback
+      (obj->*fp)(ros1_msg);
+    });
+
+  // Full forward to ROS 1.
+  ros1_subscriber_ = ros1_node.subscribe<Ros1MessageT>(
+    topic, queue_size, fp, obj, transport_hints);
+}
+
+// const fp version of the above
+template<class M, class T>
+void subscribe(ros::NodeHandle& ros1_node, const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj, 
+    const ros::TransportHints& transport_hints = ros::TransportHints())
+{
+  // Set up ROS 2 subscription with a lambda that converts and calls the ROS 1-style const callback
+  rclcpp::Node::SharedPtr node = ros2in1_support::getRos2Node();
+  ros2_subscription_ = node->create_subscription<Ros2MessageT>(
+    topic, make_qos_from_transport_hints(queue_size, transport_hints),
+    [fp, obj](const typename Ros2MessageT::SharedPtr ros2_msg) {
+      Ros1MessageT ros1_msg;
+      conversions::convert_2_to_1(*ros2_msg, ros1_msg);
+      // Call the ROS 1-style const callback
+      (obj->*fp)(ros1_msg);
+    });
+
+  // Full forward to ROS 1.
+  ros1_subscriber_ = ros1_node.subscribe<Ros1MessageT>(
+    topic, queue_size, fp, obj, transport_hints);
+}
+#if 0
+  template<class M, class T>
+  void subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&), T* obj, 
+                       const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+  }
+  template<class M, class T>
+  void subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj, 
+                       const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M, class T>
+  void subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), 
+                       const boost::shared_ptr<T>& obj, const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M, class T>
+  void subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, 
+                       const boost::shared_ptr<T>& obj, const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M, class T>
+  void subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&), 
+                       const boost::shared_ptr<T>& obj, const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+  template<class M, class T>
+  void subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&) const, 
+                       const boost::shared_ptr<T>& obj, const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M>
+  void subscribe(const std::string& topic, uint32_t queue_size, void(*fp)(M), const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M>
+  void subscribe(const std::string& topic, uint32_t queue_size, void(*fp)(const boost::shared_ptr<M const>&), const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M>
+  void subscribe(const std::string& topic, uint32_t queue_size, const boost::function<void (const boost::shared_ptr<M const>&)>& callback,
+                             const ros::VoidConstPtr& tracked_object = ros::VoidConstPtr(), const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+
+  template<class M, class C>
+  void subscribe(const std::string& topic, uint32_t queue_size, const boost::function<void (C)>& callback,
+                             const ros::VoidConstPtr& tracked_object = ros::VoidConstPtr(), const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+
+  }
+#endif
+
+  explicit operator bool() const {
+    return ros1_subscriber_ && ros2_subscription_;
+  }
+
+ private:
+  ros::Subscriber ros1_subscriber_;
+  typename rclcpp::Subscription<Ros2MessageT>::SharedPtr ros2_subscription_;
+};
+
+#else  // ROS2_SUPPORT
+
+namespace ros2in1_support {
+
+template <typename Ros1MessageT>
+class Subscriber {
+ public:
+ /// TODO Add the wrappers to ROS 1 API
+
+  explicit operator bool() const {
+    return ros1_publisher_;
+  }
+
+ private:
+  ros::Subscriber ros1_subscriber_;
+  std::shared_ptr<void> ros2_subscription_;  // for identical memory layout independent of ROS2_SUPPORT
+};
+
+#endif  // ROS2_SUPPORT
+
+}  // namespace ros2in1_support
+
+# endif  // ROS2IN1_SUPPORT_PUBLISHER_H

--- a/package.xml
+++ b/package.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2in1_support</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>CMake macros and functions to help finding and using ROS 2 dependencies in ROS 1 packages</description>
 
-  <maintainer email="info@intermodalics.eu">Intermodalics BV</maintainer>
+  <maintainer email="info@intermodalics.ai">Intermodalics BV</maintainer>
   <author>Johannes Meyer</author>
-  <license>Closed</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
# Goal

The goal is to make it possible to subscribe to both ROS 1 and ROS 2 topics with ROS 2-in-1 support.

## Description

This PR adds a new class `ros2in1_support::Subscriber<>` that can be used to create a ROS 1 and ROS 2 subscriber to a topic. The ROS 2 subscription callback convert and forwards the message to user-provided ROS 1 signature callback.

The user can create a subscriber by, e.g.:

```cpp
ros2in1_support::Subscriber<std_msgs::Header> headers_sub_;
```

and initialize it by:

```cpp
headers_sub_.subscribe("topic/of/type/header", 1, [](const std_msgs::Header::ConstPtr header){
    do_something(header);
  });
```

The `subscribe()` function supports a few callback headers, but not all the signatures supported by ROS 1 are implemented currently.
