### PR TITLE
add conversions for geometry_msgs/Twist interface

### DIFF
--- a/include/ros2in1_support/conversions/geometry_msgs.h
+++ b/include/ros2in1_support/conversions/geometry_msgs.h
@@ -246,8 +246,16 @@ template <>
 inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
     const geometry_msgs::msg::Twist& ros2_msg,
     geometry_msgs::Twist& ros1_msg) {
-  convert_2_to_1(ros2_msg.linear, ros1_msg.linear);
-  convert_2_to_1(ros2_msg.angular, ros1_msg.angular);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.linear, ros1_msg.linear);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.angular, ros1_msg.angular);
+}
+
+template <>
+inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
+    geometry_msgs::msg::Twist&& ros2_msg,
+    geometry_msgs::Twist& ros1_msg) {
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.linear, ros1_msg.linear);
+  convert_2_to_1<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>(ros2_msg.angular, ros1_msg.angular);
 }
 
 template <>

--- a/include/ros2in1_support/conversions/geometry_msgs.h
+++ b/include/ros2in1_support/conversions/geometry_msgs.h
@@ -15,6 +15,7 @@
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 
@@ -26,6 +27,7 @@
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Transform.h>
 #include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/Twist.h>
 #include <geometry_msgs/Vector3.h>
 #include <geometry_msgs/Vector3Stamped.h>
 
@@ -59,6 +61,9 @@ template <> struct Ros2MessageType<geometry_msgs::Transform> {
 };
 template <> struct Ros2MessageType<geometry_msgs::TransformStamped> {
   typedef geometry_msgs::msg::TransformStamped type;
+};
+template <> struct Ros2MessageType<geometry_msgs::Twist> {
+  typedef geometry_msgs::msg::Twist type;
 };
 template <> struct Ros2MessageType<geometry_msgs::Vector3> {
   typedef geometry_msgs::msg::Vector3 type;
@@ -235,6 +240,22 @@ inline void convert_1_to_2<geometry_msgs::msg::TransformStamped, geometry_msgs::
   convert_1_to_2(ros1_msg.header, ros2_msg.header);
   ros2_msg.child_frame_id = ros1_msg.child_frame_id;
   convert_1_to_2(ros1_msg.transform, ros2_msg.transform);
+}
+
+template <>
+inline void convert_2_to_1<geometry_msgs::Twist, geometry_msgs::msg::Twist>(
+    const geometry_msgs::msg::Twist& ros2_msg,
+    geometry_msgs::Twist& ros1_msg) {
+  convert_2_to_1(ros2_msg.linear, ros1_msg.linear);
+  convert_2_to_1(ros2_msg.angular, ros1_msg.angular);
+}
+
+template <>
+inline void convert_1_to_2<geometry_msgs::msg::Twist, geometry_msgs::Twist>(
+    const geometry_msgs::Twist& ros1_msg,
+    geometry_msgs::msg::Twist& ros2_msg) {
+  convert_1_to_2(ros1_msg.linear, ros2_msg.linear);
+  convert_1_to_2(ros1_msg.angular, ros2_msg.angular);
 }
 
 }  // namespace conversions

--- a/include/ros2in1_support/conversions/nav_msgs.h
+++ b/include/ros2in1_support/conversions/nav_msgs.h
@@ -115,8 +115,7 @@ inline void convert_2_to_1<nav_msgs::Odometry, nav_msgs::msg::Odometry>(
   convert_2_to_1(ros2_msg.pose.pose.position, ros1_msg.pose.pose.position);
   convert_2_to_1(ros2_msg.pose.pose.orientation, ros1_msg.pose.pose.orientation);
   convert_2_to_1(ros2_msg.pose.covariance, ros1_msg.pose.covariance);
-  convert_2_to_1(ros2_msg.twist.twist.linear, ros1_msg.twist.twist.linear);
-  convert_2_to_1(ros2_msg.twist.twist.angular, ros1_msg.twist.twist.angular);
+  convert_2_to_1(ros2_msg.twist.twist, ros1_msg.twist.twist);
   convert_2_to_1(ros2_msg.twist.covariance, ros1_msg.twist.covariance);
 }
 
@@ -129,8 +128,7 @@ inline void convert_1_to_2<nav_msgs::msg::Odometry, nav_msgs::Odometry>(
   convert_1_to_2(ros1_msg.pose.pose.position, ros2_msg.pose.pose.position);
   convert_1_to_2(ros1_msg.pose.pose.orientation, ros2_msg.pose.pose.orientation);
   convert_1_to_2(ros1_msg.pose.covariance, ros2_msg.pose.covariance);
-  convert_1_to_2(ros1_msg.twist.twist.linear, ros2_msg.twist.twist.linear);
-  convert_1_to_2(ros1_msg.twist.twist.angular, ros2_msg.twist.twist.angular);
+  convert_2_to_1(ros2_msg.twist.twist, ros1_msg.twist.twist);
   convert_1_to_2(ros1_msg.twist.covariance, ros2_msg.twist.covariance);
 }
 


### PR DESCRIPTION

# Goal

To support a minimal example that uses `geometry_msgs::Twist`.

## Details

This PR extends out-of-the-box support of `ros2in1_support` to cover `geometry_msgs::Twist` by implementing the trait and conversion functions required for that message.